### PR TITLE
Fix ArxivFetcher when fetching stops

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -193,6 +193,7 @@ llmodels/
 
 # data folder
 data/*.pdf
+data/*.txt
 
 # tutos data
 tutorials/data/

--- a/ragxiv/text/arxiv_extractor.py
+++ b/ragxiv/text/arxiv_extractor.py
@@ -24,6 +24,7 @@ class ArxivFetcher:
         category: str = "cond-mat.str-el",
         max_results: int = 100,
         data_folder: str = "data",
+        fetched_arxiv_ids_file: str = "fetched_arxiv_ids.txt",
         **kwargs,
     ):
         """
@@ -37,6 +38,7 @@ class ArxivFetcher:
             max_results (int, optional): The maximum number of results to fetch from arXiv. A typical value when
                 running the code would be 1000 (see https://info.arxiv.org/help/api/user-manual.html#3112-start-and-max_results-paging). Default is 5.
             data_folder (str, optional): The folder where to store the PDFs and other data. Default is "data".
+            fetched_arxiv_ids_file (str, optional): The file where to store the fetched arXiv IDs. Default is "fetched_arxiv_ids.txt".
         """
         self.category = category
         self.max_results = max_results
@@ -44,6 +46,8 @@ class ArxivFetcher:
         # check if `data_folder` exists, and if not, create it
         Path(data_folder).mkdir(parents=True, exist_ok=True)
         self.data_folder = Path(data_folder)
+        # file to store fetched arXiv IDs
+        self.fetched_ids_file = self.data_folder / fetched_arxiv_ids_file
 
         self.logger = kwargs.get("logger", logger)
         self.session = requests.Session()  # Reuse TCP connection
@@ -51,26 +55,30 @@ class ArxivFetcher:
         # ! otherwise, long papers get stuck on `requests.get()` due to connection timeouts
         self.session.head("http://arxiv.org/pdf/2502.10309v1", timeout=30)
 
-    def fetch(
-        self, fetched_ids_path: str = "fetched_arxiv_ids.txt", batch_size: int = 100
-    ) -> list:
+    @property
+    def fetched_ids(self) -> set[str]:
+        """
+        Get the set of fetched arXiv IDs from the `fetched_arxiv_ids.txt` file.
+
+        Returns:
+            set[str]: A set of fetched arXiv IDs.
+        """
+        if not self.fetched_ids_file.exists():
+            return set()
+        with open(self.fetched_ids_file) as f:
+            return set(line.strip() for line in f if line.strip())
+
+    def fetch(self, batch_size: int = 100) -> list:
         """
         Fetch new papers from arXiv, skipping already fetched ones, and stores their metadata in an `ArxivPaper`
         pydantic models. New fetched arXiv IDs will be appended to `data/fetched_arxiv_ids.txt`.
 
         Args:
-            fetched_ids_path (str, optional): Path to the file storing fetched arXiv IDs. Default is "fetched_arxiv_ids.txt".
             batch_size (int, optional): The number of papers to fetch in each request. Default is 100.
 
         Returns:
             list: A list of `ArxivPaper` objects with the metadata of the papers fetched from arXiv.
         """
-        # Load already fetched IDs into a set
-        fetched_ids_file = self.data_folder / fetched_ids_path
-        fetched_ids = set()
-        if fetched_ids_file.exists():
-            with open(fetched_ids_file) as f:
-                fetched_ids = set(line.strip() for line in f if line.strip())
 
         def _get_pages_and_figures(comment: str) -> tuple[int | None, int | None]:
             """
@@ -89,6 +97,9 @@ class ArxivFetcher:
                 n_pages, n_figures = match.groups()
                 return int(n_pages), int(n_figures)
             return None, None
+
+        # Load already fetched IDs into a set
+        fetched_ids = self.fetched_ids
 
         new_papers = []
         start_index = 0
@@ -122,12 +133,21 @@ class ArxivFetcher:
                 # If there is an error in the fetching, skip the paper
                 if "Error" in paper.get("title", ""):
                     self.logger.error("Error fetching the paper")
+                    new_papers = papers
                     continue
 
                 # If there is no `id`, skip the paper
                 url_id = paper.get("id")
                 if not url_id or "arxiv.org" not in url_id:
                     self.logger.error(f"Paper without a valid URL id: {url_id}")
+                    new_papers = papers
+                    continue
+
+                # If there is no `summary`, skip the paper
+                summary = paper.get("summary")
+                if not summary:
+                    self.logger.error(f"Paper {url_id} without summary/abstract")
+                    new_papers = papers
                     continue
 
                 # Getting arXiv `id`, and skipping if already fetched
@@ -170,7 +190,7 @@ class ArxivFetcher:
                         updated=paper.get("updated"),
                         published=paper.get("published"),
                         title=paper.get("title"),
-                        summary=paper.get("summary"),
+                        summary=summary,
                         authors=authors,
                         comment=comment,
                         n_pages=n_pages,
@@ -187,11 +207,16 @@ class ArxivFetcher:
 
             start_index += batch_size
 
-        # Save newly fetched IDs
-        if new_papers:
-            with open(fetched_ids_file, "a") as f:
+        # Save newly fetched IDs if these are all `ArxivPaper` objects and contain the `id` attribute
+        if all(isinstance(p, ArxivPaper) and p.id is not None for p in new_papers):
+            with open(self.fetched_ids_file, "a") as f:
                 for paper in new_papers:
                     f.write(f"{paper.id}\n")
+
+        # If not all papers are `ArxivPaper` objects, return an empty list
+        if not all(isinstance(p, ArxivPaper) for p in new_papers):
+            return []
+
         return new_papers
 
     def download_pdf(self, arxiv_paper: ArxivPaper, write: bool = True) -> Path:
@@ -358,6 +383,7 @@ def arxiv_fetch_and_extract(
     category: str = "cond-mat.str-el",
     max_results: int = 100,
     data_folder: str = "data",
+    fetched_arxiv_ids_file: str = "fetched_arxiv_ids.txt",
     loader: str = "pdfminer",
     logger: "BoundLoggerLazyProxy" = logger,
 ) -> list[ArxivPaper]:
@@ -377,6 +403,7 @@ def arxiv_fetch_and_extract(
         max_results (int, optional): The maximum number of results to fetch from arXiv. A typical value when
             running the code would be 1000 (see https://info.arxiv.org/help/api/user-manual.html#3112-start-and-max_results-paging). Default is 5.
         data_folder (str, optional): The folder where to store the PDFs. Defaults to "data".
+        fetched_arxiv_ids_file (str, optional): The file where to store the fetched arXiv IDs. Defaults to "fetched_arxiv_ids.txt".
         loader (str, optional): The loader to use for extracting text from the PDF file. Defaults to "pdfminer".
         logger (BoundLoggerLazyProxy, optional): The logger to log messages. Defaults to logger.
 
@@ -389,6 +416,7 @@ def arxiv_fetch_and_extract(
         category=category,
         max_results=max_results,
         data_folder=data_folder,
+        fetched_arxiv_ids_file=fetched_arxiv_ids_file,
     )
     text_extractor = TextExtractor(logger=logger)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,8 +25,18 @@ def cleared_log_storage():
     yield log_storage
 
 
-def generate_arxiv_fetcher(category: str = "cond-mat.str-el", max_results: int = 1):
-    return ArxivFetcher(category=category, max_results=max_results)
+def generate_arxiv_fetcher(
+    category: str = "cond-mat.str-el",
+    max_results: int = 1,
+    data_folder: str = "tests/data",
+    fetched_arxiv_ids_file: str = "fetched_arxiv_ids.txt",
+):
+    return ArxivFetcher(
+        category=category,
+        max_results=max_results,
+        data_folder=data_folder,
+        fetched_arxiv_ids_file=fetched_arxiv_ids_file,
+    )
 
 
 def generate_arxiv_paper(id: str = "1234.5678v1"):

--- a/tutorials/script_testing.py
+++ b/tutorials/script_testing.py
@@ -1,7 +1,7 @@
 pdf = "./tests/data/2502.12144v1.pdf"
 
-from ragxiv.text.chunker import Chunker
-from ragxiv.text.arxiv_extractor import TextExtractor
+from ragxiv.logger import logger
+from ragxiv.text import ArxivFetcher, Chunker, TextExtractor
 from ragxiv.prompts import (
     EXP_OR_COMP_TEMPLATE,
     EXTRACT_METHODS_TEMPLATE,
@@ -9,6 +9,11 @@ from ragxiv.prompts import (
     prompt,
 )
 from ragxiv.rag import CustomRetriever, LangChainRetriever, LLMGenerator, answer_to_dict
+
+papers = fetcher = ArxivFetcher(
+    logger=logger,
+    max_results=5,
+).fetch(batch_size=2)
 
 extractor = TextExtractor()
 text = extractor.get_text(pdf_path=pdf, loader="pdfminer")


### PR DESCRIPTION
This pull request introduces enhancements to the `ArxivFetcher` class and its associated methods, improving the handling of large datasets and streamlining the workflow for fetching, storing, and processing arXiv papers. Key changes include support for batch fetching, tracking fetched IDs, and centralizing the data folder configuration.

### Enhancements to `ArxivFetcher`:

* **Batch Fetching and ID Tracking**:
  - Added support for fetching papers in batches using the `batch_size` parameter, enabling efficient handling of large datasets. [[1]](diffhunk://#diff-59109d4d8994fe96d6de036c6b8f93f5e0e38db1c5ffcf907314b9974f27f8bcR93-R110) [[2]](diffhunk://#diff-59109d4d8994fe96d6de036c6b8f93f5e0e38db1c5ffcf907314b9974f27f8bcL151-R214)
  - Implemented functionality to skip already fetched papers by tracking their IDs in a file (`fetched_arxiv_ids.txt`). Newly fetched IDs are appended to this file for future reference. [[1]](diffhunk://#diff-59109d4d8994fe96d6de036c6b8f93f5e0e38db1c5ffcf907314b9974f27f8bcL102-R145) [[2]](diffhunk://#diff-59109d4d8994fe96d6de036c6b8f93f5e0e38db1c5ffcf907314b9974f27f8bcL151-R214)

* **Centralized Data Folder Management**:
  - Introduced the `data_folder` parameter to specify where PDFs and metadata are stored. The folder is created automatically if it does not exist. This simplifies file management across methods. [[1]](diffhunk://#diff-59109d4d8994fe96d6de036c6b8f93f5e0e38db1c5ffcf907314b9974f27f8bcL25-R26) [[2]](diffhunk://#diff-59109d4d8994fe96d6de036c6b8f93f5e0e38db1c5ffcf907314b9974f27f8bcL151-R214)

### Updates to Associated Methods:

* **Improved Paper Metadata Extraction**:
  - Enhanced logic for extracting authors, categories, and other metadata, ensuring robust handling of edge cases in the XML response.

* **Modified `download_pdf` Method**:
  - Removed the `data_folder` parameter from `download_pdf` in favor of using the centralized `data_folder` attribute within the class.

### Integration and Testing:

* **Integration in `arxiv_fetch_and_extract`**:
  - Updated the `arxiv_fetch_and_extract` function to initialize `ArxivFetcher` with the new `data_folder` parameter and utilize batch fetching. [[1]](diffhunk://#diff-59109d4d8994fe96d6de036c6b8f93f5e0e38db1c5ffcf907314b9974f27f8bcL322-R359) [[2]](diffhunk://#diff-59109d4d8994fe96d6de036c6b8f93f5e0e38db1c5ffcf907314b9974f27f8bcL349-R392)
  
* **Testing Script Updates**:
  - Modified the testing script to use the updated `ArxivFetcher` class, demonstrating batch fetching with a smaller batch size for testing purposes. [[1]](diffhunk://#diff-41921f29bbd5061316ec195eb06795bf782a4184784401e393b09257522458e7L3-R4) [[2]](diffhunk://#diff-41921f29bbd5061316ec195eb06795bf782a4184784401e393b09257522458e7R13-R17)